### PR TITLE
Update some docs & update backward() 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Feature Selection Using AIC and BIC
 Version: 4.0.0
 Authors@R: c(
     person("Tariq", "Hassan", , email="tariq.hassan@alumni.ubc.ca", role=c("aut")),
-    person("Jill", "Cates", , email="jill.cates@alumni.ubc.ca", role=c("aut")),
-    person("Avinash", "Prabhakaran", , email="avinash.prabhakaran@alumni.ubc.ca", role=c("aut", "cre"))
+    person("Jill", "Cates", , email="jill.cates@alumni.ubc.ca", role=c("aut", "cre")),
+    person("Avinash", "Prabhakaran", , email="avinash.prabhakaran@alumni.ubc.ca", role=c("aut"))
     )
 Description: 'punisheR' is a package that provides you with the tools to perform forward and backward selection using AIC and BIC. 
 License: BSD_3_clause + file LICENSE

--- a/R/backward.R
+++ b/R/backward.R
@@ -2,7 +2,7 @@ source("R/checks.R")
 source("R/utils.R")
 
 
-#' Backward Selection Algorithm.
+#' Backward Selection Algorithm
 #'
 #' @description
 #' This is an implementation of the backward selection algorithm
@@ -14,12 +14,12 @@ source("R/utils.R")
 #' @param X_train Training data. Represented as a 2D matrix or dataframe of (observations, features).
 #'
 #' @param y_train Target class for training data. Represented as a 1D vector of target classes for \code{X_train}.
-#'                If y_train is a character string AND X is a dataframe, it will be extracted from X.
+#'                If \code{y_train} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.
 #'
 #' @param X_val Validation data. Represented as a 2D matrix or dataframe of (observations, features).
 #'
 #' @param y_val Target class for validation data. Represented as a 1D vector of target classes for \code{X_val}.
-#'              If y_val is a character string AND X is a dataframe, it will be extracted from X.
+#'              If \code{y_val} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.
 #'
 #' @param criterion Model selection criterion to measure relative model quality. Can be one of:
 #' \itemize{
@@ -29,10 +29,10 @@ source("R/utils.R")
 #' }
 #'
 #' @param min_change The smallest change in criterion score to be considered significant.
-#'                   Note: `n_features` must be NULL if this is numeric.
+#'                   Note: \code{n_features} must be NULL if this is numeric.
 #'
 #' @param n_features The number of features to select, expressed either as a proportion (0,1)
-#' or whole number with range (0,total_features). Note: `min_change` must be NULL if this is numeric.
+#' or whole number with range (0,total_features). Note: \code{min_change} must be NULL if this is numeric.
 #'
 #' @param verbose
 #'  if \code{TRUE}, print additional information as selection occurs

--- a/R/backward.R
+++ b/R/backward.R
@@ -66,6 +66,10 @@ backward <- function(X_train,
     X_val <- test[[1]]
     y_val <- test[[2]]
 
+    # Set n_features to NULL if min_features arg is passed into function
+    if (!is.null(min_change) & missing(n_features)) {
+        n_features <- NULL
+    }
     input_checks(n_features = n_features,
                  min_change = min_change,
                  criterion = criterion)

--- a/R/criterion.R
+++ b/R/criterion.R
@@ -39,7 +39,7 @@ r_squared <- function(fit_model, X, y) {
 #' @description A helper function that gets the coefficients required for
 #' AIC and BIC calculations.
 #'
-#' @param model base R model object
+#' @param model Base R model object
 #'
 #' @return A vector of \code{n} (number of samples), \code{k} (number of features),
 #' \code{llf} (maximized value of log-likelihood function)
@@ -74,10 +74,10 @@ r_squared <- function(fit_model, X, y) {
 #' @param model A base R model object (e.g., \code{lm()})
 #'
 #' @param X Validation data as a 2D matrix of (observations, features).
-#' If NULL, extract `X` from `model`.
+#' If \code{NULL}, extract \code{X} from \code{model}.
 #'
 #' @param y True labels as a 1D vector.
-#'          If NULL, extract `y` from `model`.
+#'          If \code{NULL}, extract \code{y} from \code{model}.
 #'
 #' @return  AIC value gets returned as a float.
 #'
@@ -109,10 +109,10 @@ aic <- function(model, X = NULL, y = NULL) {
 #' @param  model A base R model object (e.g., \code{lm()})
 #'
 #' @param X Validation data as a 2D matrix of (observations, features).
-#' If NULL, extract `X` from `model`.
+#' If \code{NULL}, extract \code{X} from \code{model}.
 #'
 #' @param y True labels as a 1D vector.
-#'          If NULL, extract `y` from `model`.
+#'          If \code{NULL}, extract \code{y} from \code{model}.
 #'
 #' @return BIC value gets returned as a float.
 #'

--- a/R/example_data.R
+++ b/R/example_data.R
@@ -1,13 +1,13 @@
 #' Generating example data with mtcars.
 #'
 #' @description Generates test data using base R's mtcars dataset.
-#' The response variable `y` is horsepower (`hp`), while the remaining variables
-#' represent the predictive features `X`.
+#' The response variable \code{y} is horsepower (hp), while the remaining variables
+#' represent the predictive features \code{X}.
 #'
 #' @param seed random seed to use.
 #' Defaults to 99.
 #'
-#' @return X_train, y_train, X_val, y_val (as a list of dataframes)
+#' @return \code{X_train}, \code{y_train}, \code{X_val}, \code{y_val} (as a list of dataframes)
 #'
 #' @export
 mtcars_data <- function(seed=99) {
@@ -16,11 +16,11 @@ mtcars_data <- function(seed=99) {
     X$hp <- NULL
     set.seed(seed)
     training <- sample(rep(c(TRUE, TRUE, TRUE, FALSE), nrow(mtcars) / 4))
-    # Training Data ---
+    # Training Data
     X_train <- X[training,]
     y_train <- y[training]
 
-    # Validation Data ---
+    # Validation Data
     X_val <- X[!training,]
     y_val <- y[!training]
     return(list(X_train, y_train, X_val, y_val))

--- a/R/forward.R
+++ b/R/forward.R
@@ -5,19 +5,19 @@ source("R/utils.R")
 #'
 #' @description Checks if \code{forward()} should break.
 #'
-#' @param S A vector of selected features in \code{forward()} and \code{backward()}
+#' @param S A vector of selected features in \code{forward()} and \code{backward()}.
 #'
-#' @param current_best_j A vector representing the best feature currently in \code{forward()}
+#' @param current_best_j A vector representing the best feature currently in \code{forward()}.
 #'
-#' @param j_score_dict A dictionary of scores in step 1 of \code{forward()}
+#' @param j_score_dict A dictionary of scores in step 1 of \code{forward()}.
 #'
-#' @param n_features A numeric `n_features` object as developed inside \code{forward()}
+#' @param n_features A numeric \code{n_features} object as developed inside \code{forward()}.
 #'
 #' @param min_change The smallest change in criterion score to be considered significant.
 #'
-#' @param total_number_of_features The total number of features in \code{X_train}/\code{X_train}
+#' @param total_number_of_features The total number of features in \code{X_train}/\code{X_train}.
 #'
-#' @return A logical that represents whether or not \code{forward()} should halt
+#' @return A logical that represents whether or not \code{forward()} should halt.
 #'
 #' @keywords internal
 .forward_break_criteria <-
@@ -57,12 +57,12 @@ source("R/utils.R")
 #' @param X_train Training data. Represented as a 2D matrix or dataframe of (observations, features).
 #'
 #' @param y_train Target class for training data. Represented as a 1D vector of target classes for \code{X_train}.
-#'                If y_train is a character string AND X is a dataframe, it will be extracted from X.
+#'                If \code{y_train} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.
 #'
 #' @param X_val Validation data. Represented as a 2D matrix or dataframe of (observations, features).
 #'
 #' @param y_val Target class for validation data. Represented as a 1D vector of target classes for \code{X_val}.
-#'              If y_val is a character string AND X is a dataframe, it will be extracted from X.
+#'              If \code{y_val} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.
 #'
 #' @param criterion Model selection criterion to measure relative model quality. Can be one of:
 #' \itemize{
@@ -72,13 +72,13 @@ source("R/utils.R")
 #' }
 #'
 #' @param min_change The smallest change in criterion score to be considered significant.
-#'                   Note: `n_features` must be NULL if this is numeric.
+#'                   Note: \code{n_features} must be NULL if this is numeric.
 #'
 #' @param n_features The number of features to select, expressed either as a proportion (0,1)
-#' or whole number with range (0,total_features). Note: `min_change` must be NULL if this is numeric.
+#' or whole number with range (0,total_features). Note: \code{min_change} must be NULL if this is numeric.
 #'
 #' @param verbose
-#'  if \code{TRUE}, print additional information as selection occurs
+#'  If \code{TRUE}, print additional information as selection occurs
 #'
 #' @examples
 #' X_train <- matrix(runif(50, 0, 50), ncol=5)

--- a/R/forward.R
+++ b/R/forward.R
@@ -108,7 +108,7 @@ forward <- function(X_train,
     X_val <- test[[1]]
     y_val <- test[[2]]
 
-    # Set min_change to null if n_features arg is passed into function
+    # Set min_change to NULL if n_features arg is passed into function
     if (!is.null(n_features) & missing(min_change)) {
         min_change <- NULL
     }

--- a/man/aic.Rd
+++ b/man/aic.Rd
@@ -10,10 +10,10 @@ aic(model, X = NULL, y = NULL)
 \item{model}{A base R model object (e.g., \code{lm()})}
 
 \item{X}{Validation data as a 2D matrix of (observations, features).
-If NULL, extract `X` from `model`.}
+If \code{NULL}, extract \code{X} from \code{model}.}
 
 \item{y}{True labels as a 1D vector.
-If NULL, extract `y` from `model`.}
+If \code{NULL}, extract \code{y} from \code{model}.}
 }
 \value{
 AIC value gets returned as a float.

--- a/man/backward.Rd
+++ b/man/backward.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/backward.R
 \name{backward}
 \alias{backward}
-\title{Backward Selection Algorithm.}
+\title{Backward Selection Algorithm}
 \usage{
 backward(X_train, y_train, X_val, y_val, n_features = 0.5,
   min_change = NULL, criterion = "r-squared", verbose = TRUE)
@@ -11,18 +11,18 @@ backward(X_train, y_train, X_val, y_val, n_features = 0.5,
 \item{X_train}{Training data. Represented as a 2D matrix or dataframe of (observations, features).}
 
 \item{y_train}{Target class for training data. Represented as a 1D vector of target classes for \code{X_train}.
-If y_train is a character string AND X is a dataframe, it will be extracted from X.}
+If \code{y_train} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.}
 
 \item{X_val}{Validation data. Represented as a 2D matrix or dataframe of (observations, features).}
 
 \item{y_val}{Target class for validation data. Represented as a 1D vector of target classes for \code{X_val}.
-If y_val is a character string AND X is a dataframe, it will be extracted from X.}
+If \code{y_val} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.}
 
 \item{n_features}{The number of features to select, expressed either as a proportion (0,1)
-or whole number with range (0,total_features). Note: `min_change` must be NULL if this is numeric.}
+or whole number with range (0,total_features). Note: \code{min_change} must be NULL if this is numeric.}
 
 \item{min_change}{The smallest change in criterion score to be considered significant.
-Note: `n_features` must be NULL if this is numeric.}
+Note: \code{n_features} must be NULL if this is numeric.}
 
 \item{criterion}{Model selection criterion to measure relative model quality. Can be one of:
 \itemize{

--- a/man/bic.Rd
+++ b/man/bic.Rd
@@ -10,10 +10,10 @@ bic(model, X = NULL, y = NULL)
 \item{model}{A base R model object (e.g., \code{lm()})}
 
 \item{X}{Validation data as a 2D matrix of (observations, features).
-If NULL, extract `X` from `model`.}
+If \code{NULL}, extract \code{X} from \code{model}.}
 
 \item{y}{True labels as a 1D vector.
-If NULL, extract `y` from `model`.}
+If \code{NULL}, extract \code{y} from \code{model}.}
 }
 \value{
 BIC value gets returned as a float.

--- a/man/forward.Rd
+++ b/man/forward.Rd
@@ -11,18 +11,18 @@ forward(X_train, y_train, X_val, y_val, min_change = 0.5, n_features = NULL,
 \item{X_train}{Training data. Represented as a 2D matrix or dataframe of (observations, features).}
 
 \item{y_train}{Target class for training data. Represented as a 1D vector of target classes for \code{X_train}.
-If y_train is a character string AND X is a dataframe, it will be extracted from X.}
+If \code{y_train} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.}
 
 \item{X_val}{Validation data. Represented as a 2D matrix or dataframe of (observations, features).}
 
 \item{y_val}{Target class for validation data. Represented as a 1D vector of target classes for \code{X_val}.
-If y_val is a character string AND X is a dataframe, it will be extracted from X.}
+If \code{y_val} is a character string AND \code{X} is a dataframe, it will be extracted from \code{X}.}
 
 \item{min_change}{The smallest change in criterion score to be considered significant.
-Note: `n_features` must be NULL if this is numeric.}
+Note: \code{n_features} must be NULL if this is numeric.}
 
 \item{n_features}{The number of features to select, expressed either as a proportion (0,1)
-or whole number with range (0,total_features). Note: `min_change` must be NULL if this is numeric.}
+or whole number with range (0,total_features). Note: \code{min_change} must be NULL if this is numeric.}
 
 \item{criterion}{Model selection criterion to measure relative model quality. Can be one of:
 \itemize{
@@ -31,7 +31,7 @@ or whole number with range (0,total_features). Note: `min_change` must be NULL i
  \item 'r-squared': use coefficient of determination
 }}
 
-\item{verbose}{if \code{TRUE}, print additional information as selection occurs}
+\item{verbose}{If \code{TRUE}, print additional information as selection occurs}
 }
 \value{
 A vector of indices that represent the best features of the model.

--- a/man/mtcars_data.Rd
+++ b/man/mtcars_data.Rd
@@ -11,10 +11,10 @@ mtcars_data(seed = 99)
 Defaults to 99.}
 }
 \value{
-X_train, y_train, X_val, y_val (as a list of dataframes)
+\code{X_train}, \code{y_train}, \code{X_val}, \code{y_val} (as a list of dataframes)
 }
 \description{
 Generates test data using base R's mtcars dataset.
-The response variable `y` is horsepower (`hp`), while the remaining variables
-represent the predictive features `X`.
+The response variable \code{y} is horsepower (hp), while the remaining variables
+represent the predictive features \code{X}.
 }

--- a/tests/testthat/test-backward.R
+++ b/tests/testthat/test-backward.R
@@ -403,7 +403,7 @@ test_that("backward() selects the best features
 
 
 test_that("backward() selects at least
-          some features with `min_change` (small)", {
+          some features using r-squared with `min_change` (small)", {
     # Testing `min_change`
     output <- backward(
         X_train,
@@ -447,5 +447,40 @@ test_that("backward() selects more best features when
               # Test that large_min_change output is greater than
               # or equal to small_min_change output
               expect_gte(length(large_min_change), length(small_min_change))
+          })
+
+
+test_that("backward() selects at least
+          some features using `min_change` and criterion 'aic'", {
+              # Testing `min_change` and criterion = 'aic'
+              output <- backward(
+                  X_train,
+                  y_train,
+                  X_val,
+                  y_val,
+                  n_features = NULL,
+                  min_change = 100,
+                  criterion = 'aic',
+                  verbose = FALSE
+              )
+              # Test for output greater than or equal to 1 (i.e., some features)
+              expect_gte(length(output), 1)
+          })
+
+test_that("backward() selects at least
+          some features using `min_change` and criterion 'bic'", {
+              # Testing `min_change` and criterion = 'bic'
+              output <- backward(
+                  X_train,
+                  y_train,
+                  X_val,
+                  y_val,
+                  n_features = NULL,
+                  min_change = 100,
+                  criterion = 'bic',
+                  verbose = FALSE
+              )
+              # Test for output greater than or equal to 1 (i.e., some features)
+              expect_gte(length(output), 1)
           })
 

--- a/tests/testthat/test-backward.R
+++ b/tests/testthat/test-backward.R
@@ -475,7 +475,6 @@ test_that("backward() selects at least
                   y_train,
                   X_val,
                   y_val,
-                  n_features = NULL,
                   min_change = 100,
                   criterion = 'bic',
                   verbose = FALSE

--- a/tests/testthat/test-forward.R
+++ b/tests/testthat/test-forward.R
@@ -404,7 +404,7 @@ test_that("forward() selects the best features
 })
 
 test_that("forward() selects the best features
-          from mtcars dataset using `min_change`", {
+          from mtcars dataset using `min_change` and r-squared criterion", {
     # Test that a small `min_change` will result in the
     # length of output being greater than or equal to 1
     output <- forward(
@@ -418,3 +418,36 @@ test_that("forward() selects the best features
     )
     expect_gt(length(output), 1)
 })
+
+test_that("forward() selects the best features
+          from mtcars dataset using `min_change` and AIC criterion", {
+              # Test that a small `min_change` will result in the
+              # length of output being greater than or equal to 1
+              output <- forward(
+                  X_train,
+                  y_train,
+                  X_val,
+                  y_val,
+                  min_change = 100,
+                  criterion = 'aic',
+                  verbose = FALSE
+              )
+              expect_gt(length(output), 1)
+          })
+
+test_that("forward() selects the best features
+          from mtcars dataset using `min_change` and BIC criterion", {
+              # Test that a small `min_change` will result in the
+              # length of output being greater than or equal to 1
+              output <- forward(
+                  X_train,
+                  y_train,
+                  X_val,
+                  y_val,
+                  min_change = 100,
+                  criterion = 'bic',
+                  verbose = FALSE
+              )
+              expect_gt(length(output), 1)
+          })
+


### PR DESCRIPTION
For backward(): set `n_features` to NULL if min_features arg is passed into function

Allows you to do this:

```
backward(X_train, y_train, X_val, y_val, min_change = 0.1, criterion = "r-squared", verbose = TRUE)
```

instead of this:

```
backward(X_train, y_train, X_val, y_val, n_features=NULL, min_change = 0.1, criterion = "r-squared", verbose = TRUE)
```
